### PR TITLE
CURVE_ED25519_SHA512 should be a value that is a valid identifer

### DIFF
--- a/src/net/i2p/crypto/eddsa/spec/EdDSANamedCurveTable.java
+++ b/src/net/i2p/crypto/eddsa/spec/EdDSANamedCurveTable.java
@@ -14,7 +14,7 @@ import net.i2p.crypto.eddsa.math.ed25519.Ed25519ScalarOps;
  *
  */
 public class EdDSANamedCurveTable {
-    public static final String CURVE_ED25519_SHA512 = "ed25519-sha-512";
+    public static final String CURVE_ED25519_SHA512 = "SHA512withEd25519";
 
     private static final Field ed25519field = new Field(
                     256, // b


### PR DESCRIPTION
By having the value of the CURVE_ED25519_SHA512 be a valid identifier, using it via external sources (such as a protocol buffers enum) becomes much easier and doesn't require a translation layer. 

I chose this value as it's what the BouncyCastle (and I think the default implementation?) use for ECDSA. "CURVE_ED25519_SHA512" would also be usable.